### PR TITLE
Use a notification pipe to handle signals

### DIFF
--- a/lib/sidekiq/process_manager/manager.rb
+++ b/lib/sidekiq/process_manager/manager.rb
@@ -1,13 +1,10 @@
 # frozen_string_literal: true
 
 require "sidekiq"
-require "sidekiq/util"
 
 module Sidekiq
   module ProcessManager
     class Manager
-      include Sidekiq::Util
-
       attr_reader :cli
 
       def initialize(process_count: 1, prefork: false, preboot: nil, mode: nil, silent: false)
@@ -58,7 +55,9 @@ module Sidekiq
           end
         end
 
-        @signal_thread = safe_thread("signal_handler") do
+        @signal_thread = Thread.new do
+          Thread.current.name = "signal_handler"
+
           while signal_pipe_read.wait_readable
             signal = signal_pipe_read.gets.strip
             send_signal_to_children(signal.to_sym)

--- a/spec/sidekiq/process_manager/manager_spec.rb
+++ b/spec/sidekiq/process_manager/manager_spec.rb
@@ -38,12 +38,14 @@ describe Sidekiq::ProcessManager::Manager do
 
     it "should exit when all child processes have terminated with an INT signal" do
       ::Process.kill(:INT, ::Process.pid)
+      sleep 1 # allow the signal pipe time to process the signal
       manager.wait
       expect(manager.pids.size).to eq 0
     end
 
     it "should exit when all child processes have terminated with a TERM signal" do
       ::Process.kill(:TERM, ::Process.pid)
+      sleep 1 # allow the signal pipe time to process the signal
       manager.wait
       expect(manager.pids.size).to eq 0
     end


### PR DESCRIPTION
When shutting down sidekiq-process-manager the following lines get
logged:

```
log writing failed. can't be called from trap context
log writing failed. can't be called from trap context
log writing failed. can't be called from trap context
log writing failed. can't be called from trap context
```

This is due to Ruby 2+ not allowing the use of Mutex within
`Signal.trap` and Logger uses Mutex. To fix this I've implemented a
system similar to how Sidekiq handles signals. Within `Signal.trap` the
signal is written to a pipe. I then create a thread that reads the pipe
and when a signal is sent over it it calls `send_signal_to_children`.

We've been running this in production for a few weeks now and it's
working great.

References:
- https://docs.ruby-lang.org/en/3.0/doc/signals_rdoc.html
- https://www.mikeperham.com/2013/02/23/signal-handling-with-ruby/
- https://bugs.ruby-lang.org/issues/7917
- https://github.com/mperham/sidekiq/blob/f3c8c3482277ec3876ce68d49ca7abad8e716b4c/lib/sidekiq/cli.rb#L44-L62
- https://github.com/mperham/sidekiq/blob/f3c8c3482277ec3876ce68d49ca7abad8e716b4c/lib/sidekiq/cli.rb#L118-L121