### PR TITLE
CI: Add Ruby 3.3 + sidekiq 7 to test matrix

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -26,6 +26,8 @@ jobs:
         include:
           - ruby: "ruby"
             standardrb: true
+          - ruby: "3.3"
+            appraisal: "sidekiq_7.x"
           - ruby: "3.2"
             appraisal: "sidekiq_7.x"
           - ruby: "3.1"


### PR DESCRIPTION
This PR extends the test matrix with the latest generally available Ruby.